### PR TITLE
Fix liquidity chart

### DIFF
--- a/src/components/LiquidityChartRangeInput/Chart.tsx
+++ b/src/components/LiquidityChartRangeInput/Chart.tsx
@@ -1,6 +1,7 @@
 import { max, scaleLinear, stack, sum, ZoomTransform } from 'd3'
 import { darken } from 'polished'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { Bound } from 'state/mint/v3/actions'
 
 import { Area } from './Area'
 import { AxisBottom } from './AxisBottom'
@@ -22,6 +23,7 @@ export function Chart({
   keys,
   hiddenKeyIndexes,
   selectedKeyIndex,
+  ticksAtLimit,
   styles,
   dimensions: { width, height },
   margins,
@@ -111,8 +113,10 @@ export function Chart({
             'reset'
           )
         }}
-        showResetButton
+        showResetButton={Boolean(ticksAtLimit[Bound.LOWER] || ticksAtLimit[Bound.UPPER])}
         zoomLevels={zoomLevels}
+        brushDomain={brushDomain}
+        currentPrice={current}
       />
       <svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`} style={{ overflow: 'visible' }}>
         <defs>

--- a/src/components/LiquidityChartRangeInput/Zoom.tsx
+++ b/src/components/LiquidityChartRangeInput/Zoom.tsx
@@ -71,10 +71,12 @@ const fitZoomContent = ({
   const start = xScale(brushDomain[0])
   const end = xScale(brushDomain[1])
   const diff = end - start
-  const translateSlope = -width / (currentPrice * (1 - zoomLevels.initialMin)) / 2
-  const translateConstant = -(translateSlope * currentPrice * zoomLevels.initialMin)
+  const initialMin = currentPrice * zoomLevels.initialMin
+  const initialMax = currentPrice * zoomLevels.initialMax
+  const translateSlope = width / (initialMax - initialMin)
+  const translateConstant = -(translateSlope * initialMin)
   const center = (brushDomain[1] - brushDomain[0]) * 0.5 + brushDomain[0]
-  const to = -(center * translateSlope + translateConstant)
+  const to = center * translateSlope + translateConstant
   select(svg as Element)
     .call(zoomBehavior.translateTo, to, 0)
     .transition()

--- a/src/components/LiquidityChartRangeInput/index.tsx
+++ b/src/components/LiquidityChartRangeInput/index.tsx
@@ -23,21 +23,30 @@ import { ZoomLevels } from './types'
 import { VisiblilitySelector } from './VisibilitySelector'
 
 const SMALL_ZOOM_LEVEL: ZoomLevels = {
-  initialMin: 0.999,
+  initialMin: 1 / 1.001,
   initialMax: 1.001,
   min: 0.00001,
   max: 1.5,
 }
 
 const MEDIUM_ZOOM_LEVEL: ZoomLevels = {
-  initialMin: 0.5,
+  initialMin: 1 / 1.2,
+  initialMax: 1.2,
+  min: 0.00001,
+  max: 20,
+}
+
+const LARGE_ZOOM_LEVEL: ZoomLevels = {
+  initialMin: 1 / 2,
   initialMax: 2,
   min: 0.00001,
   max: 20,
 }
 
-const getZoomLevel = (tickSpacing?: number) =>
-  typeof tickSpacing === 'number' && tickSpacing < 60 ? SMALL_ZOOM_LEVEL : MEDIUM_ZOOM_LEVEL
+const getZoomLevel = (tickSpacing?: number) => {
+  if (tickSpacing == null) return LARGE_ZOOM_LEVEL
+  return tickSpacing < 15 ? SMALL_ZOOM_LEVEL : tickSpacing < 50 ? MEDIUM_ZOOM_LEVEL : LARGE_ZOOM_LEVEL
+}
 
 const ChartWrapper = styled.div`
   position: relative;

--- a/src/components/LiquidityChartRangeInput/index.tsx
+++ b/src/components/LiquidityChartRangeInput/index.tsx
@@ -235,6 +235,7 @@ export default function LiquidityChartRangeInput({
               brushDomain={brushDomain}
               onBrushDomainChange={onBrushDomainChangeEnded}
               zoomLevels={getZoomLevel(pool?.tickSpacing)}
+              ticksAtLimit={ticksAtLimit}
             />
           </ChartWrapper>
           {keys.length > 1 && (

--- a/src/components/LiquidityChartRangeInput/index.tsx
+++ b/src/components/LiquidityChartRangeInput/index.tsx
@@ -235,7 +235,6 @@ export default function LiquidityChartRangeInput({
               brushDomain={brushDomain}
               onBrushDomainChange={onBrushDomainChangeEnded}
               zoomLevels={getZoomLevel(pool?.tickSpacing)}
-              ticksAtLimit={ticksAtLimit}
             />
           </ChartWrapper>
           {keys.length > 1 && (

--- a/src/components/LiquidityChartRangeInput/types.ts
+++ b/src/components/LiquidityChartRangeInput/types.ts
@@ -1,5 +1,3 @@
-import { Bound } from 'state/mint/v3/actions'
-
 export interface ChartEntry {
   activeLiquidity: Record<number, number>
   price0: number
@@ -35,7 +33,6 @@ export interface LiquidityChartRangeInputProps {
   keys: string[]
   hiddenKeyIndexes: number[]
   selectedKeyIndex?: number
-  ticksAtLimit: { [bound in Bound]?: boolean | undefined }
 
   styles: {
     area: {

--- a/src/components/LiquidityChartRangeInput/types.ts
+++ b/src/components/LiquidityChartRangeInput/types.ts
@@ -1,3 +1,5 @@
+import { Bound } from 'state/mint/v3/actions'
+
 export interface ChartEntry {
   activeLiquidity: Record<number, number>
   price0: number
@@ -33,6 +35,7 @@ export interface LiquidityChartRangeInputProps {
   keys: string[]
   hiddenKeyIndexes: number[]
   selectedKeyIndex?: number
+  ticksAtLimit: { [bound in Bound]?: boolean | undefined }
 
   styles: {
     area: {

--- a/src/state/data/slice.ts
+++ b/src/state/data/slice.ts
@@ -40,6 +40,11 @@ export const api = createApi({
         document: gql`
           query allV3Ticks($poolId: String!, $skip: Int!) {
             tiers(first: 1000, where: { poolId: $poolId }, orderBy: tierId) {
+              tick
+              liquidity
+              sqrtGamma
+              nextTickBelow
+              nextTickAbove
               ticks(first: 1000, skip: $skip, orderBy: tickIdx) {
                 tickIdx
                 tierId


### PR DESCRIPTION
 - Use subgraph data to calculate tier's liquidity instead of on chain data to prevent data mismatch after position minted/burnt
 - Reset brush and reset zoom after changing tier
 - Add fit brush area button